### PR TITLE
Make PSR-16 benchmarks to use cache entry class

### DIFF
--- a/bench/MultiCacheHit.php
+++ b/bench/MultiCacheHit.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lcobucci\CacheBench;
 
+use Lcobucci\CacheStuff\Psr16CacheEntry;
 use PhpBench\Benchmark\Metadata\Annotations\AfterMethods;
 use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
 use function assert;
@@ -24,8 +25,8 @@ final class MultiCacheHit extends CacheComparison
             $key          = 'item-for-retrieval-' . $i;
             $this->keys[] = $key;
 
-            $this->psr16Roave->set($key, 'retrieve-me');
-            $this->psr16Naive->set($key, 'retrieve-me');
+            $this->psr16Roave->set($key, new Psr16CacheEntry('retrieve-me'));
+            $this->psr16Naive->set($key, new Psr16CacheEntry('retrieve-me'));
             $this->psr6Symfony->save($this->psr6SymfonyFactory->getItem($key)->set('retrieve-me'));
         }
     }
@@ -40,14 +41,14 @@ final class MultiCacheHit extends CacheComparison
     public function benchPsr16Roave(): void
     {
         foreach ($this->psr16Roave->getMultiple($this->keys) as $item) {
-            assert($item === 'retrieve-me');
+            assert($item->data === 'retrieve-me');
         }
     }
 
     public function benchPsr16Naive(): void
     {
         foreach ($this->psr16Naive->getMultiple($this->keys) as $item) {
-            assert($item === 'retrieve-me');
+            assert($item->data === 'retrieve-me');
         }
     }
 

--- a/bench/MultiCacheHitAndMiss.php
+++ b/bench/MultiCacheHitAndMiss.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Lcobucci\CacheBench;
 
+use Lcobucci\CacheStuff\CacheEntry;
+use Lcobucci\CacheStuff\Psr16CacheEntry;
 use PhpBench\Benchmark\Metadata\Annotations\AfterMethods;
 use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
 use Psr\Cache\CacheItemInterface;
@@ -35,8 +37,8 @@ final class MultiCacheHitAndMiss extends CacheComparison
 
             $value = $i % 10 === 0 ? false : 'retrieve-me';
 
-            $this->psr16Roave->set($key, $value);
-            $this->psr16Naive->set($key, $value);
+            $this->psr16Roave->set($key, new Psr16CacheEntry($value));
+            $this->psr16Naive->set($key, new Psr16CacheEntry($value));
             $this->psr6Symfony->save($this->psr6SymfonyFactory->getItem($key)->set($value));
         }
     }
@@ -57,7 +59,7 @@ final class MultiCacheHitAndMiss extends CacheComparison
             ++$count;
 
             $expectedValue = $this->getExpectedValue($key);
-            assert($item === $expectedValue);
+            assert(!$expectedValue || $item->data === $expectedValue);
         }
 
         assert($count === count($this->keys));
@@ -72,7 +74,7 @@ final class MultiCacheHitAndMiss extends CacheComparison
             ++$count;
 
             $expectedValue = $this->getExpectedValue($key);
-            assert($item === $expectedValue);
+            assert(!$expectedValue || $item->data === $expectedValue);
         }
 
         assert($count === count($this->keys));

--- a/bench/MultiRemove.php
+++ b/bench/MultiRemove.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lcobucci\CacheBench;
 
+use Lcobucci\CacheStuff\Psr16CacheEntry;
 use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
 use function assert;
 
@@ -20,8 +21,8 @@ final class MultiRemove extends CacheComparison
             $key          = 'item-for-retrieval-' . $i;
             $this->keys[] = $key;
 
-            $this->psr16Roave->set($key, 'retrieve-me');
-            $this->psr16Naive->set($key, 'retrieve-me');
+            $this->psr16Roave->set($key, new Psr16CacheEntry('retrieve-me'));
+            $this->psr16Naive->set($key, new Psr16CacheEntry('retrieve-me'));
             $this->psr6Symfony->save($this->psr6SymfonyFactory->getItem($key)->set('retrieve-me'));
         }
     }

--- a/bench/MultiSaveWithoutTTL.php
+++ b/bench/MultiSaveWithoutTTL.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lcobucci\CacheBench;
 
+use Lcobucci\CacheStuff\Psr16CacheEntry;
 use PhpBench\Benchmark\Metadata\Annotations\AfterMethods;
 use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
 use function array_keys;
@@ -20,7 +21,7 @@ final class MultiSaveWithoutTTL extends CacheComparison
     public function populate(): void
     {
         for ($i = 0; $i < 1000; ++$i) {
-            $this->items['save-without-ttl-' . $i] = 'a-simple-item';
+            $this->items['save-without-ttl-' . $i] = new Psr16CacheEntry('a-simple-item');
         }
     }
 

--- a/bench/SingleCacheHit.php
+++ b/bench/SingleCacheHit.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lcobucci\CacheBench;
 
+use Lcobucci\CacheStuff\Psr16CacheEntry;
 use PhpBench\Benchmark\Metadata\Annotations\AfterMethods;
 use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
 use function assert;
@@ -17,8 +18,8 @@ final class SingleCacheHit extends CacheComparison
     {
         $this->init();
 
-        $this->psr16Roave->set('item-for-retrieval', 'retrieve-me');
-        $this->psr16Naive->set('item-for-retrieval', 'retrieve-me');
+        $this->psr16Roave->set('item-for-retrieval', new Psr16CacheEntry('retrieve-me'));
+        $this->psr16Naive->set('item-for-retrieval', new Psr16CacheEntry('retrieve-me'));
         $this->psr6Symfony->save($this->psr6SymfonyFactory->getItem('item-for-retrieval')->set('retrieve-me'));
     }
 
@@ -31,12 +32,12 @@ final class SingleCacheHit extends CacheComparison
 
     public function benchPsr16Roave(): void
     {
-        assert($this->psr16Roave->get('item-for-retrieval') === 'retrieve-me');
+        assert($this->psr16Roave->get('item-for-retrieval')->data === 'retrieve-me');
     }
 
     public function benchPsr16Naive(): void
     {
-        assert($this->psr16Naive->get('item-for-retrieval') === 'retrieve-me');
+        assert($this->psr16Naive->get('item-for-retrieval')->data === 'retrieve-me');
     }
 
     public function benchPsr6Symfony(): void

--- a/bench/SingleRemove.php
+++ b/bench/SingleRemove.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lcobucci\CacheBench;
 
+use Lcobucci\CacheStuff\Psr16CacheEntry;
 use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
 use function assert;
 
@@ -13,8 +14,8 @@ final class SingleRemove extends CacheComparison
     {
         $this->init();
 
-        $this->psr16Roave->set('item-for-removal', 'remove-me');
-        $this->psr16Naive->set('item-for-removal', 'remove-me');
+        $this->psr16Roave->set('item-for-removal', new Psr16CacheEntry('remove-me'));
+        $this->psr16Naive->set('item-for-removal', new Psr16CacheEntry('remove-me'));
         $this->psr6Symfony->save($this->psr6SymfonyFactory->getItem('item-for-removal')->set('remove-me'));
     }
 

--- a/bench/SingleSaveWithTTL.php
+++ b/bench/SingleSaveWithTTL.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lcobucci\CacheBench;
 
+use Lcobucci\CacheStuff\Psr16CacheEntry;
 use PhpBench\Benchmark\Metadata\Annotations\AfterMethods;
 
 /** @AfterMethods({"cleanup"}) */
@@ -17,12 +18,12 @@ final class SingleSaveWithTTL extends CacheComparison
 
     public function benchPsr16Roave(): void
     {
-        $this->psr16Roave->set('save-with-ttl', 'a-simple-item', 86400);
+        $this->psr16Roave->set('save-with-ttl', new Psr16CacheEntry('a-simple-item'), 86400);
     }
 
     public function benchPsr16Naive(): void
     {
-        $this->psr16Naive->set('save-with-ttl', 'a-simple-item', 86400);
+        $this->psr16Naive->set('save-with-ttl', new Psr16CacheEntry('a-simple-item'), 86400);
     }
 
     public function benchPsr6Symfony(): void

--- a/bench/SingleSaveWithoutTTL.php
+++ b/bench/SingleSaveWithoutTTL.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lcobucci\CacheBench;
 
+use Lcobucci\CacheStuff\Psr16CacheEntry;
 use PhpBench\Benchmark\Metadata\Annotations\AfterMethods;
 
 /** @AfterMethods({"cleanup"}) */
@@ -17,12 +18,12 @@ final class SingleSaveWithoutTTL extends CacheComparison
 
     public function benchPsr16Roave(): void
     {
-        $this->psr16Roave->set('save-without-ttl', 'a-simple-item');
+        $this->psr16Roave->set('save-without-ttl', new Psr16CacheEntry('a-simple-item'));
     }
 
     public function benchPsr16Naive(): void
     {
-        $this->psr16Naive->set('save-without-ttl', 'a-simple-item');
+        $this->psr16Naive->set('save-without-ttl', new Psr16CacheEntry('a-simple-item'));
     }
 
     public function benchPsr6Symfony(): void

--- a/lib/Psr16CacheEntry.php
+++ b/lib/Psr16CacheEntry.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lcobucci\CacheStuff;
+
+/**
+ * This class is necessary for PSR-16 to correctly handle null values, otherwise there is no way to differentiate
+ * saved null value from cache miss.
+ */
+final class Psr16CacheEntry
+{
+    public $data;
+
+    public function __construct($data)
+    {
+        $this->data = $data;
+    }
+}


### PR DESCRIPTION
This is requirement for PSR-16 in cases where we need to differentiate
between missing value and null value saved in cache. PSR-6 has other
means for that, so does not force consumer to do it.

New results:

```
33 subjects, 33 iterations, 330 revs, 0 rejects, 0 failures, 0 warnings
(best [mean mode] worst) = 146.300 [4,262.139 4,262.139] 146.300 (μs)
⅀T: 140,650.600μs μSD/r 0.000μs μRSD/r: 0.000%
suite: 13417ecbc89cc3b3df2c874bbb8b8debe710a670, date: 2019-12-12, stime: 22:23:52
+----------------------+------------------+-----+------+-----+------------+--------------+--------------+--------------+--------------+---------+--------+---------+
| benchmark            | subject          | set | revs | its | mem_peak   | best         | mean         | mode         | worst        | stdev   | rstdev | diff    |
+----------------------+------------------+-----+------+-----+------------+--------------+--------------+--------------+--------------+---------+--------+---------+
| MultiCacheMiss       | benchPsr16Roave  | 0   | 10   | 1   | 2,144,576b | 15,478.100μs | 15,478.100μs | 15,478.100μs | 15,478.100μs | 0.000μs | 0.00%  | 105.80x |
| MultiCacheMiss       | benchPsr16Naive  | 0   | 10   | 1   | 1,647,552b | 1,067.100μs  | 1,067.100μs  | 1,067.100μs  | 1,067.100μs  | 0.000μs | 0.00%  | 7.29x   |
| MultiCacheMiss       | benchPsr6Symfony | 0   | 10   | 1   | 1,800,504b | 1,450.500μs  | 1,450.500μs  | 1,450.500μs  | 1,450.500μs  | 0.000μs | 0.00%  | 9.91x   |
| SingleCacheHit       | benchPsr16Roave  | 0   | 10   | 1   | 1,513,440b | 197.800μs    | 197.800μs    | 197.800μs    | 197.800μs    | 0.000μs | 0.00%  | 1.35x   |
| SingleCacheHit       | benchPsr16Naive  | 0   | 10   | 1   | 1,513,440b | 170.500μs    | 170.500μs    | 170.500μs    | 170.500μs    | 0.000μs | 0.00%  | 1.17x   |
| SingleCacheHit       | benchPsr6Symfony | 0   | 10   | 1   | 1,513,448b | 220.900μs    | 220.900μs    | 220.900μs    | 220.900μs    | 0.000μs | 0.00%  | 1.51x   |
| SingleCacheMiss      | benchPsr16Roave  | 0   | 10   | 1   | 1,458,376b | 302.900μs    | 302.900μs    | 302.900μs    | 302.900μs    | 0.000μs | 0.00%  | 2.07x   |
| SingleCacheMiss      | benchPsr16Naive  | 0   | 10   | 1   | 1,458,376b | 230.800μs    | 230.800μs    | 230.800μs    | 230.800μs    | 0.000μs | 0.00%  | 1.58x   |
| SingleCacheMiss      | benchPsr6Symfony | 0   | 10   | 1   | 1,491,080b | 241.500μs    | 241.500μs    | 241.500μs    | 241.500μs    | 0.000μs | 0.00%  | 1.65x   |
| SingleRemove         | benchPsr16Roave  | 0   | 10   | 1   | 1,511,800b | 146.700μs    | 146.700μs    | 146.700μs    | 146.700μs    | 0.000μs | 0.00%  | 1.00x   |
| SingleRemove         | benchPsr16Naive  | 0   | 10   | 1   | 1,511,800b | 164.800μs    | 164.800μs    | 164.800μs    | 164.800μs    | 0.000μs | 0.00%  | 1.13x   |
| SingleRemove         | benchPsr6Symfony | 0   | 10   | 1   | 1,511,808b | 146.300μs    | 146.300μs    | 146.300μs    | 146.300μs    | 0.000μs | 0.00%  | 1.00x   |
| MultiSaveWithTTL     | benchPsr16Roave  | 0   | 10   | 1   | 2,103,008b | 22,579.200μs | 22,579.200μs | 22,579.200μs | 22,579.200μs | 0.000μs | 0.00%  | 154.33x |
| MultiSaveWithTTL     | benchPsr16Naive  | 0   | 10   | 1   | 2,004,728b | 22,829.200μs | 22,829.200μs | 22,829.200μs | 22,829.200μs | 0.000μs | 0.00%  | 156.04x |
| MultiSaveWithTTL     | benchPsr6Symfony | 0   | 10   | 1   | 2,197,200b | 30,219.100μs | 30,219.100μs | 30,219.100μs | 30,219.100μs | 0.000μs | 0.00%  | 206.56x |
| SingleSaveWithTTL    | benchPsr16Roave  | 0   | 10   | 1   | 1,511,352b | 233.900μs    | 233.900μs    | 233.900μs    | 233.900μs    | 0.000μs | 0.00%  | 1.60x   |
| SingleSaveWithTTL    | benchPsr16Naive  | 0   | 10   | 1   | 1,511,352b | 182.800μs    | 182.800μs    | 182.800μs    | 182.800μs    | 0.000μs | 0.00%  | 1.25x   |
| SingleSaveWithTTL    | benchPsr6Symfony | 0   | 10   | 1   | 1,493,080b | 173.500μs    | 173.500μs    | 173.500μs    | 173.500μs    | 0.000μs | 0.00%  | 1.19x   |
| MultiCacheHitAndMiss | benchPsr16Roave  | 0   | 10   | 1   | 2,582,136b | 3,982.700μs  | 3,982.700μs  | 3,982.700μs  | 3,982.700μs  | 0.000μs | 0.00%  | 27.22x  |
| MultiCacheHitAndMiss | benchPsr16Naive  | 0   | 10   | 1   | 2,203,896b | 2,435.400μs  | 2,435.400μs  | 2,435.400μs  | 2,435.400μs  | 0.000μs | 0.00%  | 16.65x  |
| MultiCacheHitAndMiss | benchPsr6Symfony | 0   | 10   | 1   | 2,017,040b | 2,619.900μs  | 2,619.900μs  | 2,619.900μs  | 2,619.900μs  | 0.000μs | 0.00%  | 17.91x  |
| MultiSaveWithoutTTL  | benchPsr16Roave  | 0   | 10   | 1   | 2,537,496b | 2,733.000μs  | 2,733.000μs  | 2,733.000μs  | 2,733.000μs  | 0.000μs | 0.00%  | 18.68x  |
| MultiSaveWithoutTTL  | benchPsr16Naive  | 0   | 10   | 1   | 2,442,336b | 2,764.700μs  | 2,764.700μs  | 2,764.700μs  | 2,764.700μs  | 0.000μs | 0.00%  | 18.90x  |
| MultiSaveWithoutTTL  | benchPsr6Symfony | 0   | 10   | 1   | 2,688,056b | 19,107.600μs | 19,107.600μs | 19,107.600μs | 19,107.600μs | 0.000μs | 0.00%  | 130.61x |
| MultiRemove          | benchPsr16Roave  | 0   | 10   | 1   | 2,009,752b | 1,374.400μs  | 1,374.400μs  | 1,374.400μs  | 1,374.400μs  | 0.000μs | 0.00%  | 9.39x   |
| MultiRemove          | benchPsr16Naive  | 0   | 10   | 1   | 1,753,752b | 854.300μs    | 854.300μs    | 854.300μs    | 854.300μs    | 0.000μs | 0.00%  | 5.84x   |
| MultiRemove          | benchPsr6Symfony | 0   | 10   | 1   | 1,776,408b | 723.300μs    | 723.300μs    | 723.300μs    | 723.300μs    | 0.000μs | 0.00%  | 4.94x   |
| MultiCacheHit        | benchPsr16Roave  | 0   | 10   | 1   | 2,586,184b | 2,743.800μs  | 2,743.800μs  | 2,743.800μs  | 2,743.800μs  | 0.000μs | 0.00%  | 18.75x  |
| MultiCacheHit        | benchPsr16Naive  | 0   | 10   | 1   | 2,232,744b | 2,351.800μs  | 2,351.800μs  | 2,351.800μs  | 2,351.800μs  | 0.000μs | 0.00%  | 16.08x  |
| MultiCacheHit        | benchPsr6Symfony | 0   | 10   | 1   | 2,011,624b | 2,097.600μs  | 2,097.600μs  | 2,097.600μs  | 2,097.600μs  | 0.000μs | 0.00%  | 14.34x  |
| SingleSaveWithoutTTL | benchPsr16Roave  | 0   | 10   | 1   | 1,511,120b | 273.100μs    | 273.100μs    | 273.100μs    | 273.100μs    | 0.000μs | 0.00%  | 1.87x   |
| SingleSaveWithoutTTL | benchPsr16Naive  | 0   | 10   | 1   | 1,511,120b | 220.000μs    | 220.000μs    | 220.000μs    | 220.000μs    | 0.000μs | 0.00%  | 1.50x   |
| SingleSaveWithoutTTL | benchPsr6Symfony | 0   | 10   | 1   | 1,492,848b | 333.400μs    | 333.400μs    | 333.400μs    | 333.400μs    | 0.000μs | 0.00%  | 2.28x   |
+----------------------+------------------+-----+------+-----+------------+--------------+--------------+--------------+--------------+---------+--------+---------+
```